### PR TITLE
Cache animated? method result and ensure file is rewound

### DIFF
--- a/spec/animated_gif_detector_spec.rb
+++ b/spec/animated_gif_detector_spec.rb
@@ -24,6 +24,23 @@ describe AnimatedGifDetector do
     end
   end
 
+  context 'works over multiple calls' do
+    let(:detector) { AnimatedGifDetector.new(animated_file, buffer_size: 24) }
+
+    it 'memoizes the result of animated' do
+      expect(detector.animated?).to be true
+      expect(detector.animated?).to be true
+    end
+
+    it 'rewinds the file' do
+      detector1 = AnimatedGifDetector.new(animated_file, buffer_size: 24)
+      expect(detector1.animated?).to be true
+
+      detector2 = AnimatedGifDetector.new(animated_file, buffer_size: 24)
+      expect(detector2.animated?).to be true
+    end
+  end
+
   context 'when supplied with a fixed image' do
     let(:detector) { AnimatedGifDetector.new(fixed_file) }
 


### PR DESCRIPTION
The file was not being rewound so multiple calls of `animated?` would result in an `AnimatedGifDetector::UnrecognizedFileFormatException` error even if the file was animated. This PR memoizes the result of that method, and rewinds the file so that subsequent calls will work whether using the same detector, or creating a new one.
```
=> #<AnimatedGifDetector:0x005647e1a0be58
 @frames=0,
 @options={:buffer_size=>1024, :terminate_after=>true},
 @stream=
  #<UploadableIO:0x005647e1e87018
   @content_type="image/gif",
   @io=#<Rack::Test::UploadedFile:0x005647e252b6f8 @content_type="image/gif", @original_filename="animated.gif", @tempfile=#<File:/srv/app/public/uploads/tmp/animated.gif20170622-1-x2w94w>>,
   @magic=#<MimeMagic:0x005647e1e86258 @mediatype="image", @subtype="gif", @type="image/gif">,
   @original_filename="animated.gif">>
[2] pry(#<VideoProcessingService>)> detector.animated?
=> true
[3] pry(#<VideoProcessingService>)> detector.animated?
AnimatedGifDetector::UnrecognizedFileFormatException: AnimatedGifDetector::UnrecognizedFileFormatException
from /usr/local/bundle/gems/animated_gif_detector-0.1.0/lib/animated_gif_detector.rb:22:in `animated?'
[4] pry(#<VideoProcessingService>)> detector = AnimatedGifDetector.new(io, terminate_after: true)
=> #<AnimatedGifDetector:0x005647df356178
 @frames=0,
 @options={:buffer_size=>1024, :terminate_after=>true},
 @stream=
  #<UploadableIO:0x005647e1e87018
   @content_type="image/gif",
   @io=#<Rack::Test::UploadedFile:0x005647e252b6f8 @content_type="image/gif", @original_filename="animated.gif", @tempfile=#<File:/srv/app/public/uploads/tmp/animated.gif20170622-1-x2w94w>>,
   @magic=#<MimeMagic:0x005647e1e86258 @mediatype="image", @subtype="gif", @type="image/gif">,
   @original_filename="animated.gif">>
[5] pry(#<VideoProcessingService>)> detector.animated?
AnimatedGifDetector::UnrecognizedFileFormatException: AnimatedGifDetector::UnrecognizedFileFormatException
from /usr/local/bundle/gems/animated_gif_detector-0.1.0/lib/animated_gif_detector.rb:22:in `animated?'
```